### PR TITLE
Redesign API of runner package

### DIFF
--- a/internal/jobs/create.go
+++ b/internal/jobs/create.go
@@ -19,18 +19,9 @@ import (
 func CreateFromCronJob(
 	ctx context.Context,
 	clientset kubernetes.Interface,
-	namespace, cronJobName string,
+	cronJob *batchv1.CronJob,
 	env map[string]string,
 ) (*batchv1.Job, error) {
-	cronJob, err := clientset.BatchV1().CronJobs(namespace).Get(ctx, cronJobName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("get error: %w", err)
-	}
-	slog.Info("Found the CronJob",
-		slog.Group("cronJob",
-			slog.String("namespace", cronJob.Namespace),
-			slog.String("name", cronJob.Name)))
-
 	jobToCreate := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    cronJob.Namespace,
@@ -48,7 +39,7 @@ func CreateFromCronJob(
 		},
 		Spec: appendEnv(cronJob.Spec.JobTemplate.Spec, env),
 	}
-	job, err := clientset.BatchV1().Jobs(namespace).Create(ctx, &jobToCreate, metav1.CreateOptions{})
+	job, err := clientset.BatchV1().Jobs(cronJob.Namespace).Create(ctx, &jobToCreate, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("create error: %w", err)
 	}

--- a/internal/jobs/create_test.go
+++ b/internal/jobs/create_test.go
@@ -15,35 +15,34 @@ import (
 
 func TestCreateFromCronJob(t *testing.T) {
 	t.Run("as-is", func(t *testing.T) {
-		clientset := fake.NewSimpleClientset(
-			&batchv1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "example-cronjob",
-				},
-				Spec: batchv1.CronJobSpec{
-					Suspend:  ptr.To(true),
-					Schedule: "@annual",
-					JobTemplate: batchv1.JobTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels:      map[string]string{"my/label": "foo"},
-							Annotations: map[string]string{"my/annotation": "bar"},
-						},
-						Spec: batchv1.JobSpec{
-							BackoffLimit: ptr.To[int32](1),
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{
-										Name: "example-container",
-									}},
-								},
+		clientset := fake.NewSimpleClientset()
+		cronJob := batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "example-cronjob",
+			},
+			Spec: batchv1.CronJobSpec{
+				Suspend:  ptr.To(true),
+				Schedule: "@annual",
+				JobTemplate: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels:      map[string]string{"my/label": "foo"},
+						Annotations: map[string]string{"my/annotation": "bar"},
+					},
+					Spec: batchv1.JobSpec{
+						BackoffLimit: ptr.To[int32](1),
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "example-container",
+								}},
 							},
 						},
 					},
 				},
 			},
-		)
-		gotJob, err := CreateFromCronJob(context.TODO(), clientset, "default", "example-cronjob", nil)
+		}
+		gotJob, err := CreateFromCronJob(context.TODO(), clientset, &cronJob, nil)
 		if err != nil {
 			t.Fatalf("CreateFromCronJob error: %s", err)
 		}
@@ -77,32 +76,30 @@ func TestCreateFromCronJob(t *testing.T) {
 	})
 
 	t.Run("env is given", func(t *testing.T) {
-		clientset := fake.NewSimpleClientset(
-			&batchv1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "example-cronjob",
-				},
-				Spec: batchv1.CronJobSpec{
-					Suspend:  ptr.To(true),
-					Schedule: "@annual",
-					JobTemplate: batchv1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
-							BackoffLimit: ptr.To[int32](1),
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{
-										Name: "example-container",
-									}},
-								},
+		clientset := fake.NewSimpleClientset()
+		cronJob := batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "example-cronjob",
+			},
+			Spec: batchv1.CronJobSpec{
+				Suspend:  ptr.To(true),
+				Schedule: "@annual",
+				JobTemplate: batchv1.JobTemplateSpec{
+					Spec: batchv1.JobSpec{
+						BackoffLimit: ptr.To[int32](1),
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name: "example-container",
+								}},
 							},
 						},
 					},
 				},
 			},
-		)
-		gotJob, err := CreateFromCronJob(context.TODO(), clientset, "default", "example-cronjob",
-			map[string]string{"FOO": "bar"})
+		}
+		gotJob, err := CreateFromCronJob(context.TODO(), clientset, &cronJob, map[string]string{"FOO": "bar"})
 		if err != nil {
 			t.Fatalf("CreateFromCronJob error: %s", err)
 		}

--- a/runner/types.go
+++ b/runner/types.go
@@ -2,6 +2,16 @@ package runner
 
 import "fmt"
 
+// JobFailedError represents an error that the Job has failed.
+type JobFailedError struct {
+	JobNamespace string
+	JobName      string
+}
+
+func (err JobFailedError) Error() string {
+	return fmt.Sprintf("job %s/%s failed", err.JobNamespace, err.JobName)
+}
+
 // Logger is an interface to handle the logs.
 type Logger interface {
 	// PrintContainerLog prints the container log.


### PR DESCRIPTION
- Rename to `RunCronJob()`
- Add `RunJob()`
- Receive an object such as CronJob or Job.